### PR TITLE
Update flashrom_0.9.6.1.bb

### DIFF
--- a/meta-oe/recipes-extended/flashrom/flashrom_0.9.6.1.bb
+++ b/meta-oe/recipes-extended/flashrom/flashrom_0.9.6.1.bb
@@ -5,7 +5,7 @@ HOMEPAGE = "http://flashrom.org"
 LIC_FILES_CHKSUM = "file://COPYING;md5=751419260aa954499f7abaabaa882bbe"
 DEPENDS = "pciutils"
 
-SRC_URI = "http://download.flashrom.org/releases/flashrom-${PV}.tar.bz2"
+SRC_URI = "https://download.flashrom.org/releases/flashrom-${PV}.tar.bz2"
 
 SRC_URI[md5sum] = "407e836c0a2b17ec76583cb6809f65e5"
 SRC_URI[sha256sum] = "6f7b588cce74c90b4fe9c9c794de105de76e0323442fb5770b1aeab81e9d560a"


### PR DESCRIPTION
The is a permanent redirect when attempting to download flashrom. This is suggested workaround until wget deals correctly with 308 errors.
https://github.com/facebook/openbmc/issues/78